### PR TITLE
Only have one Hibernate SessionFactory

### DIFF
--- a/src/main/java/org/jenkins/plugins/audit2db/internal/data/HibernateUtil.java
+++ b/src/main/java/org/jenkins/plugins/audit2db/internal/data/HibernateUtil.java
@@ -25,7 +25,9 @@ import org.hibernate.tool.hbm2ddl.SchemaExport;
  */
 public class HibernateUtil {
     private final static Logger LOGGER = Logger.getLogger(HibernateUtil.class.getName());
-
+    
+    private static SessionFactory retval = null;
+    
     private static Configuration getConfig(final Properties extraProperties) throws HibernateException {
         LOGGER.log(Level.INFO, Messages.HibernateUtil_LoadConfig());
         final Configuration config = new AnnotationConfiguration().configure();
@@ -38,7 +40,9 @@ public class HibernateUtil {
     }
 
     public static SessionFactory getSessionFactory(final Properties extraProperties) {
-        SessionFactory retval = null;
+        if (retval != null) {
+            return retval;
+        }
 
         try {
             // Load base configuration from hibernate.cfg.xml


### PR DESCRIPTION
I think this is the root cause of this plugin causing too many DB connections especially when one has many Jenkins slaves.
I have tested this change on local setting.
